### PR TITLE
Add a namespace prefix for the autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "autoload": {
         "psr-0": {
-            "": "src/"
+            "Akeneo": "src/"
         }
     },
     "config": {


### PR DESCRIPTION
This makes the autoloader more efficient as it avoids looking for any class in `vendor/akeneo/phpspec-skip-example-extension/src` when they have no chance to be there (a string-prefix match is faster than a `file_exists` check)
