### PR TITLE
Rely on phpspec stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "phpspec/phpspec": "2.1.0-RC1"
+        "phpspec/phpspec": "~2.1"
     },
     "autoload": {
         "psr-0": {
@@ -19,7 +19,6 @@
     "config": {
         "bin-dir": "bin"
     },
-    "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"


### PR DESCRIPTION
Hey!

This PR bumps PHPSpec to a stable constraint since it has been released and remove the minimum-stability which is by default stable. 

Is it possible to release a new version when it will be merged?

Thanks!