### PR TITLE
Stabilize phpspec

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "phpspec/phpspec": "2.1.0-RC1"
+        "phpspec/phpspec": "2.1.*"
     },
     "autoload": {
         "psr-0": {
@@ -22,7 +22,8 @@
     "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev",
+            "dev-1.0": "1.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/akeneo/PhpSpecSkipExampleExtension/pull/6

We introduce a branch to avoid to force PIM projects which rely on a 1.0.* tag to bump phpspec (PIM < 1.3)