### PR TITLE
Add PHP 5.5 requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "php": ">=5.5",
         "phpspec/phpspec": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Necessary because of this line: https://github.com/akeneo/PhpSpecSkipExampleExtension/blob/master/src/Akeneo/SkipExampleExtension.php#L20

(at least)